### PR TITLE
Add test for Pygame main module and configurable window

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,24 +1,57 @@
-"""Minimal Pygame application to verify the environment works."""
+"""Minimal Pygame application to verify that the environment works."""
 
+import os
 import pygame
+
+# Default window size used when no environment variables are provided.
+DEFAULT_WIDTH = 640
+DEFAULT_HEIGHT = 480
+
+
+def get_window_size() -> tuple[int, int]:
+    """Determine the window dimensions with optional environment overrides."""
+    width_env = os.getenv("PYGAME_WINDOW_WIDTH")
+    height_env = os.getenv("PYGAME_WINDOW_HEIGHT")
+
+    try:
+        width = int(width_env) if width_env is not None else DEFAULT_WIDTH
+    except ValueError:
+        width = DEFAULT_WIDTH
+
+    try:
+        height = int(height_env) if height_env is not None else DEFAULT_HEIGHT
+    except ValueError:
+        height = DEFAULT_HEIGHT
+
+    if width <= 0:
+        width = DEFAULT_WIDTH
+    if height <= 0:
+        height = DEFAULT_HEIGHT
+
+    return width, height
 
 
 def main() -> None:
     """Initialize Pygame and display an empty window until it is closed."""
+    # Initialize Pygame modules.
     pygame.init()
 
-    # Create a window with a fixed size
-    screen = pygame.display.set_mode((640, 480))
+    width, height = get_window_size()
+    # Create a window using the determined size.
+    display_surface = pygame.display.set_mode((width, height))
     pygame.display.set_caption("Pygame Setup Test")
 
-    running = True
-    while running:
+    is_running = True
+    while is_running:
         for event in pygame.event.get():
+            # Exit when the window is closed or the Escape key is pressed.
             if event.type == pygame.QUIT:
-                running = False
+                is_running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                is_running = False
 
-        # Fill the screen with a color to clear old frames
-        screen.fill((0, 0, 0))
+        # Fill the window with black to clear previous frames.
+        display_surface.fill((0, 0, 0))
         pygame.display.flip()
 
     pygame.quit()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,59 @@
+"""Tests for the Pygame application defined in src/main.py."""
+
+import os
+import sys
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+# Use the "dummy" video driver so that Pygame does not require a windowing system.
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+
+# Ensure the src directory is on the Python path for imports.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import pygame
+import main as main_module
+
+
+class TestMain(TestCase):
+    """Unit tests for the main module."""
+
+    def test_main_initializes_and_quits(self) -> None:
+        """Verify initialization, display setup, event handling, and shutdown."""
+        quit_event = pygame.event.Event(pygame.QUIT)
+        
+        with (
+            patch("pygame.init") as mock_init,
+            patch("pygame.display.set_mode", return_value=MagicMock()) as mock_set_mode,
+            patch("pygame.display.set_caption") as mock_set_caption,
+            patch("pygame.event.get", return_value=[quit_event]) as mock_get_events,
+            patch("pygame.display.flip") as mock_flip,
+            patch("pygame.quit") as mock_quit,
+        ):
+
+            # Execute the main loop once. The patched QUIT event terminates the loop immediately.
+            main_module.main()
+
+        # Initialization and shutdown should each occur exactly once.
+        mock_init.assert_called_once()
+        mock_quit.assert_called_once()
+
+        # The display should be created with positive integer dimensions.
+        mock_set_mode.assert_called_once()
+        (dimensions,), _ = mock_set_mode.call_args
+        width, height = dimensions
+        self.assertIsInstance(width, int)
+        self.assertIsInstance(height, int)
+        self.assertGreater(width, 0)
+        self.assertGreater(height, 0)
+
+        # The window title should be a meaningful non-empty string.
+        mock_set_caption.assert_called_once()
+        caption_argument = mock_set_caption.call_args[0][0]
+        self.assertIsInstance(caption_argument, str)
+        self.assertNotEqual(caption_argument, "")
+
+        # The event loop and frame update should both be performed once.
+        mock_get_events.assert_called_once()
+        mock_flip.assert_called_once()


### PR DESCRIPTION
## Summary
- add unit test covering initialization and shutdown of the Pygame demo
- allow the demo's window size to be configured through environment variables with safe defaults

## Testing
- `python -m pytest tests/test_main.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2e119f4d8832c98a9524c08f26f25